### PR TITLE
Add Xianyu Netdisk Delivery Checker

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -71,10 +71,12 @@ Name | Features | Conditions
 [JavaScript Buy SDK] - Lightweight library to build e-commerce into any website.
 [Minicart] - Improve PayPal shopping cart integration
 [ShopSavvy Data API] - Product pricing and availability data across 70K retailers via REST API.
+[Xianyu Netdisk Delivery Checker] - Free browser-side checklist for Xianyu digital-product sellers before sending netdisk links.
 
 [Minicart]: https://github.com/jeffharrell/minicart
 [JavaScript Buy SDK]: https://github.com/Shopify/js-buy-sdk
 [ShopSavvy Data API]: https://shopsavvy.com/data
+[Xianyu Netdisk Delivery Checker]: https://ronnie2025.github.io/xianyu-netdisk-delivery-checker/
 
 
 ## CMS


### PR DESCRIPTION
Adds Xianyu Netdisk Delivery Checker to the Tools section.\n\nWhy it fits:\n- It is a free browser-side tool for an e-commerce delivery workflow.\n- It helps Xianyu digital-product sellers check netdisk links before delivery.\n- It generates buyer instructions, after-sales boundaries, and an order-record CSV before the seller sends the link.\n\nNo affiliate link is included in this PR.